### PR TITLE
Rewind response stream after saving to cache

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -126,9 +126,9 @@ class Middleware
     protected function save(string $key, ?ResponseInterface $response = null, int $ttl): bool
     {
         if ($response && $response->getStatusCode() === 200) {
-            $this->cache->set($key, (string)$response->getBody(), $ttl);
+            $saved = $this->cache->set($key, (string)$response->getBody(), $ttl) ?? true;
             $response->getBody()->rewind();
-            return true;
+            return $saved;
         }
 
         return false;

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -126,7 +126,9 @@ class Middleware
     protected function save(string $key, ?ResponseInterface $response = null, int $ttl): bool
     {
         if ($response && $response->getStatusCode() === 200) {
-            return $this->cache->set($key, (string)$response->getBody(), $ttl) ?? true;
+            $this->cache->set($key, (string)$response->getBody(), $ttl);
+            $response->getBody()->rewind();
+            return true;
         }
 
         return false;

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -126,7 +126,7 @@ class Middleware
     protected function save(string $key, ?ResponseInterface $response = null, int $ttl): bool
     {
         if ($response && $response->getStatusCode() === 200) {
-            return $this->cache->set($key, (string)$response->getBody(), $ttl);
+            return $this->cache->set($key, (string)$response->getBody(), $ttl) ?? true;
         }
 
         return false;


### PR DESCRIPTION
Fix exception with message:
```Return value of Brightfish\CachingGuzzle\Middleware::save() must be of the type boolean, null returned```